### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,10 +128,10 @@
         <carbon.commons.version>4.7.11</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
-        <identity.framework.version>5.14.67</identity.framework.version>
-        <carbon.identity.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.package.import.version.range>
-        <identity.workflow.impl.bps.version>5.3.5</identity.workflow.impl.bps.version>
-        <carbon.identity.workflow.impl.bps.package.import.version.range>[5.3.5, 6.0.0)
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
+        <identity.workflow.impl.bps.version>6.0.0</identity.workflow.impl.bps.version>
+        <carbon.identity.workflow.impl.bps.package.import.version.range>[6.0.0, 7.0.0)
         </carbon.identity.workflow.impl.bps.package.import.version.range>
 
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16