### PR TITLE
Bump framework version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <carbon.commons.imp.pkg.version>[4.7.11, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <identity.framework.version>5.14.67</identity.framework.version>
-        <carbon.identity.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.14.67, 8.0.0)</carbon.identity.package.import.version.range>
         <identity.workflow.impl.bps.version>5.5.6</identity.workflow.impl.bps.version>
         <carbon.identity.workflow.impl.bps.package.import.version.range>[5.3.5, 6.0.0)
         </carbon.identity.workflow.impl.bps.package.import.version.range>


### PR DESCRIPTION
Bump framework version range to 7.x.x to support IS 7.0

Related to https://github.com/wso2/product-is/issues/19757